### PR TITLE
Add iOS SwiftUI MVP for Google Calendar checklist dashboard

### DIFF
--- a/ios-app/AgendaChecklistApp.swift
+++ b/ios-app/AgendaChecklistApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AgendaChecklistApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView(viewModel: DashboardViewModel(service: GoogleCalendarService()))
+        }
+    }
+}

--- a/ios-app/Models.swift
+++ b/ios-app/Models.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct AgendaEvent: Identifiable, Decodable {
+    let id: String
+    let title: String
+    let startDate: Date
+    let endDate: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case summary
+        case start
+        case end
+    }
+
+    enum DateCodingKeys: String, CodingKey {
+        case dateTime
+        case date
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decodeIfPresent(String.self, forKey: .summary) ?? "Sem título"
+
+        let startContainer = try container.nestedContainer(keyedBy: DateCodingKeys.self, forKey: .start)
+        let endContainer = try? container.nestedContainer(keyedBy: DateCodingKeys.self, forKey: .end)
+
+        startDate = try AgendaEvent.decodeGoogleDate(from: startContainer)
+
+        if let endContainer {
+            endDate = try? AgendaEvent.decodeGoogleDate(from: endContainer)
+        } else {
+            endDate = nil
+        }
+    }
+
+    private static func decodeGoogleDate(from container: KeyedDecodingContainer<DateCodingKeys>) throws -> Date {
+        let formatter = ISO8601DateFormatter()
+
+        if let dateTime = try? container.decode(String.self, forKey: .dateTime),
+           let parsed = formatter.date(from: dateTime) {
+            return parsed
+        }
+
+        if let dateOnly = try? container.decode(String.self, forKey: .date),
+           let parsed = ISO8601DateFormatter().date(from: dateOnly + "T00:00:00Z") {
+            return parsed
+        }
+
+        throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: "Formato de data inválido do Google Calendar"))
+    }
+}
+
+struct DailyTask: Identifiable {
+    let id: String
+    let title: String
+    let scheduledDate: Date
+    var isDone: Bool
+}
+
+struct CalendarEventsResponse: Decodable {
+    let items: [AgendaEvent]
+}

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -1,0 +1,46 @@
+# App iOS: Agenda → Checklist Diário
+
+Este diretório contém um esqueleto de app em **SwiftUI** para iOS que:
+
+1. Conecta com o **Google Calendar**.
+2. Converte compromissos do dia em um **checklist de tarefas**.
+3. Exibe um **gráfico de progresso diário** com base no que foi concluído.
+
+## Arquitetura (MVP)
+
+- `AgendaChecklistApp.swift`: ponto de entrada.
+- `Models.swift`: modelos de domínio (`AgendaEvent`, `DailyTask`).
+- `Services/GoogleCalendarService.swift`: integração com Google Calendar (REST API).
+- `ViewModels/DashboardViewModel.swift`: regra de negócio de checklist e progresso.
+- `Views/ContentView.swift`: tela principal.
+- `Views/ProgressChartView.swift`: gráfico de progresso usando `Charts`.
+
+## Como integrar com Google Calendar
+
+1. No [Google Cloud Console](https://console.cloud.google.com/):
+   - Crie um projeto.
+   - Ative a **Google Calendar API**.
+   - Configure OAuth para iOS.
+2. Instale as dependências que preferir para OAuth (`AppAuth` / `GoogleSignIn`), se necessário.
+3. Obtenha o **access token** OAuth e injete no `GoogleCalendarService`.
+4. Garanta o escopo mínimo:
+   - `https://www.googleapis.com/auth/calendar.readonly`
+
+## Regra de checklist
+
+A conversão atual é direta: cada compromisso do dia vira uma tarefa com:
+- título = título do evento;
+- horário previsto = horário de início do evento;
+- concluída = `false` inicialmente.
+
+Você pode evoluir com regras como:
+- gerar subtarefas por categoria do evento;
+- prioridade por horário de início;
+- sugestões automáticas com IA.
+
+## Próximos passos sugeridos
+
+- Persistência local (SwiftData/CoreData) para manter tarefas marcadas offline.
+- Sincronização bidirecional opcional (checklist → notas do evento).
+- Notificações locais para lembrar tarefas não concluídas.
+- Filtros por calendário (trabalho, pessoal, estudos).

--- a/ios-app/Services/GoogleCalendarService.swift
+++ b/ios-app/Services/GoogleCalendarService.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+protocol CalendarServiceProtocol {
+    func fetchEvents(for day: Date, accessToken: String) async throws -> [AgendaEvent]
+}
+
+final class GoogleCalendarService: CalendarServiceProtocol {
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetchEvents(for day: Date, accessToken: String) async throws -> [AgendaEvent] {
+        var calendar = Calendar.current
+        calendar.timeZone = TimeZone.current
+
+        let dayStart = calendar.startOfDay(for: day)
+        guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) else {
+            return []
+        }
+
+        let timeMin = ISO8601DateFormatter().string(from: dayStart)
+        let timeMax = ISO8601DateFormatter().string(from: dayEnd)
+
+        var components = URLComponents(string: "https://www.googleapis.com/calendar/v3/calendars/primary/events")
+        components?.queryItems = [
+            URLQueryItem(name: "singleEvents", value: "true"),
+            URLQueryItem(name: "orderBy", value: "startTime"),
+            URLQueryItem(name: "timeMin", value: timeMin),
+            URLQueryItem(name: "timeMax", value: timeMax)
+        ]
+
+        guard let url = components?.url else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
+        let decoded = try JSONDecoder().decode(CalendarEventsResponse.self, from: data)
+        return decoded.items
+    }
+}

--- a/ios-app/ViewModels/DashboardViewModel.swift
+++ b/ios-app/ViewModels/DashboardViewModel.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+@MainActor
+final class DashboardViewModel: ObservableObject {
+    @Published var tasks: [DailyTask] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private let service: CalendarServiceProtocol
+
+    init(service: CalendarServiceProtocol) {
+        self.service = service
+    }
+
+    var completionRate: Double {
+        guard !tasks.isEmpty else { return 0 }
+        let doneCount = tasks.filter(\.isDone).count
+        return Double(doneCount) / Double(tasks.count)
+    }
+
+    func loadToday(accessToken: String) async {
+        isLoading = true
+        errorMessage = nil
+
+        defer { isLoading = false }
+
+        do {
+            let events = try await service.fetchEvents(for: Date(), accessToken: accessToken)
+            tasks = events.map {
+                DailyTask(id: $0.id, title: $0.title, scheduledDate: $0.startDate, isDone: false)
+            }
+        } catch {
+            errorMessage = "Não foi possível carregar os compromissos: \(error.localizedDescription)"
+        }
+    }
+
+    func toggleTask(_ task: DailyTask) {
+        guard let idx = tasks.firstIndex(where: { $0.id == task.id }) else { return }
+        tasks[idx].isDone.toggle()
+    }
+}

--- a/ios-app/Views/ContentView.swift
+++ b/ios-app/Views/ContentView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject var viewModel: DashboardViewModel
+
+    // Em produção, substitua por token obtido via OAuth.
+    @State private var accessToken = "COLOQUE_SEU_ACCESS_TOKEN"
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                HStack {
+                    Text("Progresso do dia")
+                        .font(.title2.bold())
+                    Spacer()
+                    Text("\(Int(viewModel.completionRate * 100))%")
+                        .font(.headline)
+                }
+
+                ProgressChartView(
+                    done: viewModel.tasks.filter(\.isDone).count,
+                    pending: viewModel.tasks.filter { !$0.isDone }.count
+                )
+
+                List(viewModel.tasks) { task in
+                    Button {
+                        viewModel.toggleTask(task)
+                    } label: {
+                        HStack {
+                            Image(systemName: task.isDone ? "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(task.isDone ? .green : .gray)
+
+                            VStack(alignment: .leading) {
+                                Text(task.title)
+                                Text(task.scheduledDate, style: .time)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+                .listStyle(.plain)
+
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+            }
+            .padding()
+            .navigationTitle("Agenda Checklist")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Sincronizar") {
+                        Task {
+                            await viewModel.loadToday(accessToken: accessToken)
+                        }
+                    }
+                    .disabled(viewModel.isLoading)
+                }
+            }
+            .task {
+                await viewModel.loadToday(accessToken: accessToken)
+            }
+        }
+    }
+}

--- a/ios-app/Views/ProgressChartView.swift
+++ b/ios-app/Views/ProgressChartView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import Charts
+
+struct ProgressChartView: View {
+    let done: Int
+    let pending: Int
+
+    var body: some View {
+        Chart {
+            SectorMark(
+                angle: .value("Concluídas", done),
+                innerRadius: .ratio(0.55),
+                angularInset: 2
+            )
+            .foregroundStyle(.green)
+
+            SectorMark(
+                angle: .value("Pendentes", pending),
+                innerRadius: .ratio(0.55),
+                angularInset: 2
+            )
+            .foregroundStyle(.orange)
+        }
+        .frame(height: 220)
+    }
+}


### PR DESCRIPTION
### Motivation

- Criar um MVP de app iOS que se integre ao Google Calendar, converta compromissos do dia em um checklist de tarefas e mostre um gráfico de progresso diário.
- Fornecer uma base mínima (modelos, serviço de API, view model e UI) para acelerar a integração OAuth e evolução do app.

### Description

- Adiciona um scaffold SwiftUI em `ios-app/` com ponto de entrada `AgendaChecklistApp.swift` e documentação em `ios-app/README.md`.
- Implementa modelos e parsing da API do Google Calendar em `Models.swift` (`AgendaEvent`, `DailyTask`, `CalendarEventsResponse`) com suporte a `dateTime` e `date` do Google.
- Implementa `GoogleCalendarService` em `ios-app/Services/GoogleCalendarService.swift` que consulta a API REST de eventos do dia usando `timeMin/timeMax` e header `Authorization: Bearer <token>`.
- Implementa `DashboardViewModel` (`ios-app/ViewModels/DashboardViewModel.swift`) que carrega eventos, converte em `DailyTask`, calcula `completionRate` e permite alternar tarefas; e a UI em `ios-app/Views/ContentView.swift` e `ios-app/Views/ProgressChartView.swift` (gráfico com `Charts`).

### Testing

- Executado `swift --version`, que retornou a versão do compilador com sucesso.
- Tentativa de compilar com `swiftc` (`swiftc ios-app/*.swift -o /tmp/agenda-checklist`) falhou neste ambiente Linux devido à ausência dos frameworks iOS/`SwiftUI` (falha esperada fora de um macOS com SDK iOS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e129dd1ba8832182df3d36e86b702f)